### PR TITLE
Slightly modified the setup.py to support apple silicon build with brew llvm and brew gsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ It is mostly written in Cython and C in order to speed up computations.
 |:------------------:| :----------------: | :----------------: |:-----------:| :----------------: |
 | :white_check_mark: | :white_check_mark: | :white_check_mark: |     :x:     | :white_check_mark: |
 
+There are currently no wheels for Apple Silicon (macOS ARM64), but they can be built locally. On your Mac with Apple Silicon:
+- first install the required software:
+  - `brew install llvm`
+  - `brew install gsl`
+- then run `pip install .` within the repository to install `fathon`
+
 ### Prerequisites
 
  - Python 3.8 or higher
- - numpy (version >= 1.24.4 for Python < 3.12, version >= 1.26.2 for Python >= 3.12)
+ - `numpy` (version >= 1.24.4 for Python < 3.12, version >= 1.26.2 for Python >= 3.12)
+ - **Only if building locally on a Mac with Apple Silicon**, `llvm` and `gsl` installed with `brew`
 
 ### Installing
 

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,16 @@ import re
 
 if platform.system() == "Darwin":
     if platform.processor() == "arm":
-        os.environ["CC"] = "/usr/local/opt/llvm/bin/clang"
-        os.environ["LDFLAGS"] = "-L/usr/local/opt/llvm/lib"
-        os.environ["CPPFLAGS"] = "-I/usr/local/opt/llvm/include"
+        os.environ["CC"] = "/opt/homebrew/opt/llvm/bin/clang"
+        os.environ["LDFLAGS"] = "-L/opt/homebrew/opt/llvm/lib"
+        os.environ["CPPFLAGS"] = "-I/opt/homebrew/opt/llvm/include"
+        gsl_inc = "/opt/homebrew/opt/gsl/include"
+        gsl_lib = "/opt/homebrew/opt/gsl/lib"
     else:
         os.environ["CC"] = "gcc-11"
         os.environ["CXX"] = "g++-11"
-
-    gsl_inc = "/usr/local/include"
-    gsl_lib = "/usr/local/lib/"
+        gsl_inc = "/usr/local/include"
+        gsl_lib = "/usr/local/lib"
 elif platform.system() == "Linux":
     pass
 elif platform.system() == "Windows":


### PR DESCRIPTION
This is just a minor fix to support build on apple silicon.
On Mac with Apple silicon, use [Homebrew](https://brew.sh/) to install the llvm build framework and gsl library:

- `brew install llvm`
- `brew install gsl`

This should allow you to set the following in `setup.py`:
```python
os.environ["CC"] = "/opt/homebrew/opt/llvm/bin/clang"
os.environ["LDFLAGS"] = "-L/opt/homebrew/opt/llvm/lib"
os.environ["CPPFLAGS"] = "-I/opt/homebrew/opt/llvm/include"
gsl_inc = "/opt/homebrew/opt/gsl/include"
gsl_lib = "/opt/homebrew/opt/gsl/lib"
```

fathon can then be installed by running `pip install .` within the repository. Tested on an M1 macbook.